### PR TITLE
Use flash() helper method instead of dependency injection

### DIFF
--- a/app/Http/Controllers/LeadController.php
+++ b/app/Http/Controllers/LeadController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use Flasher\Prime\FlasherInterface;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
@@ -13,13 +12,13 @@ class LeadController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function index(FlasherInterface $flasher)
+    public function index()
     {
         $user = Auth::user();
         $check = $user->hasPermissionTo('lead-management');
 
         if(!$check) {
-            $flasher->addWarning('You are not authorized to access this page');
+            flash()->addWarning('You are not authorized to access this page');
             return redirect()->route('dashboard');
         }
 

--- a/app/Http/Livewire/LeadIndex.php
+++ b/app/Http/Livewire/LeadIndex.php
@@ -3,7 +3,6 @@
 namespace App\Http\Livewire;
 
 use App\Models\Lead;
-use Flasher\Prime\FlasherInterface;
 use Livewire\Component;
 use Livewire\WithPagination;
 
@@ -17,10 +16,10 @@ class LeadIndex extends Component
         ]);
     }
 
-    public function leadDelete($id, FlasherInterface $flasher) {
+    public function leadDelete($id) {
         $lead = Lead::findOrFail($id);
         $lead->delete();
 
-        $flasher->addSuccess('Lead deleted successfully');
+        flash()->addSuccess('Lead deleted successfully');
     }
 }


### PR DESCRIPTION
Salamou alaykoum @raselupm,

Thanks again for using [PHPFlasher](https://php-flasher.io/) in your tutorial.

This PR only use the `flash()` helper method instead of injecting `FlasherInterface`, here are some examples from the documentation : 

https://php-flasher.io/docs/concepts/usage/

![image](https://user-images.githubusercontent.com/10859693/210309653-b9b152fb-7b11-4f06-ba92-02cc22feeb13.png)
