### PR TITLE
We may use SELECTED date dynamically now.

### DIFF
--- a/app/Http/Livewire/CourseCreate.php
+++ b/app/Http/Livewire/CourseCreate.php
@@ -54,7 +54,7 @@ class CourseCreate extends Component
             $interval =  new DateInterval('P1D');
             $date_range = new DatePeriod($start_date, $interval, $end_date);
             foreach ($date_range as $date) {
-                if($date->format("l") === "Sunday"){ // Need to make Selected day Dynamic
+                if($date->format("l") === ucfirst($day) {
                     $curriculum = Curriculum::create([
                         'name' => $this->name.' '.$i++,
                         'course_id' => $course_id,


### PR DESCRIPTION
Before we manually put the date "Sunday" to numbering how many Sundays are there between the start and end date. So, now we may select any of the dates from our front end and don't need to change over the coursecreate.php file anymore. 

Actually, format("l") provides an example: Sunday but we stored our data in small-case and that's why need to use ucfirst($day) to equivalent our data. So, it works. 

Thanks
Roman